### PR TITLE
Add cwl-utils to code-generators and remove cwlgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ Partial implementations:
 |[acd2cwl](https://github.com/common-workflow-language/acd2cwl)|ACD (EMBOSS) to CWL generator|
 |[CTD converter](https://github.com/WorkflowConversion/CTDConverter)|Common Tool Definition (CTD) to CWL converter|
 |[scriptcwl](https://github.com/NLeSC/scriptcwl)|Create CWL workflows by writing a simple Python script|
-|[python-cwlgen](https://github.com/common-workflow-language/python-cwlgen)|Generate of CWL programmatically from Python.|
 |[cwl-to-parsl](https://github.com/benhg/cwl-to-parsl)|Convert CWL to Parsl|
 |[Beatrice](https://github.com/Parsoa/Beatrice)|Pipeline Assembler For CWL|
 |[zatsu-cwl-generator](https://github.com/tom-tan/zatsu-cwl-generator)|A simple CWL document generator from given execution commands|
+|[cwl-utils](https://github.com/common-workflow-language/cwl-utils)|New Python 3.6+ CWL parsing library|
 
 ### Code libraries
 


### PR DESCRIPTION
Closes #30 

Per conversation in 2020-08-04 community discussion.

Note, cwl-utils has slightly different text to what's in the utility section (to better describe the function in relation to the category).

