### PR TITLE
Fix nav links, Leadership Team text, Advisors.

### DIFF
--- a/content/_config.yml
+++ b/content/_config.yml
@@ -13,9 +13,8 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: CWL Staging Site
-url: ""
-baseurl: "/cwl-staging"
+title: Common Workflow Language (CWL)
+url: "https://www.commonwl.org"
 author:
   name: Common Workflow Language (CWL)
   # email: your-email@domain.com

--- a/content/_config_local.yml
+++ b/content/_config_local.yml
@@ -1,3 +1,4 @@
-url: "cwl.test" # the base hostname & protocol for your site, e.g. http://example.com
-baseurl: "/"
+title: CWL Staging Site 2
+url: "https://www.commonwl.org" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/cwl-staging"
 port: 80

--- a/content/_includes/home/contributers-and-governance.html
+++ b/content/_includes/home/contributers-and-governance.html
@@ -91,7 +91,7 @@
 
 <h3 id="CWL_Leadership_Team" class="section">CWL Leadership Team <a id="#CWL_Leadership_Team" href="#CWL_Leadership_Team" class="anchorfix"><span>§</span></a></h3>
 
-CWL is a member project of the Software Freedom Conservancy. In general, [discussions about CWL should happen on open forums](https://mail.google.com/mail/u/0/#m_-135557084554140653_Support) but you can also contact the CWL leadership team & Conservancy directly via [commonworkflowlanguage@sfconservancy.org](mailto:commonworkflowlanguage@sfconservancy.org). This address should be CC'ed regarding all activities that involve activities of Common Workflow Language that related to things other than software development and documentation, and particularly any activities that expect to make use of Software Freedom Conservancy's non-profit status.
+CWL is a member project of the Software Freedom Conservancy. In general, [discussions about CWL should happen on open forums](#Support) but you can also contact the CWL leadership team & Conservancy directly via [commonworkflowlanguage@sfconservancy.org](mailto:commonworkflowlanguage@sfconservancy.org). This address should be CC'ed regarding all activities that involve activities of Common Workflow Language that related to things other than software development and documentation, and particularly any activities that expect to make use of Software Freedom Conservancy's non-profit status.
 
 To contact just the CWL leadership team, please email [cwl-leadership@googlegroups.com](mailto:cwl-leadership@googlegroups.com).
 

--- a/content/_includes/home/contributers-and-governance.html
+++ b/content/_includes/home/contributers-and-governance.html
@@ -88,12 +88,14 @@
 *   Nebojša Tijanić, Seven Bridges
 *   Ward Vandewege, Curii / Arvados; [https://orcid.org/0000-0002-2527-6949](https://orcid.org/0000-0002-2527-6949)
 *   Alexander Wait Zaranek, Curoverse Inc. / Arvados; [https://orcid.org/0000-0002-0415-9655](https://orcid.org/0000-0002-0415-9655)
-*   Alexander Wait Zaranek, Curii / Arvados; [https://orcid.org/0000-0002-0415-965](https://orcid.org/0000-0002-0415-965)
 
 <h3 id="CWL_Leadership_Team" class="section">CWL Leadership Team <a id="#CWL_Leadership_Team" href="#CWL_Leadership_Team" class="anchorfix"><span>§</span></a></h3>
 
-(Alphabetical)
+CWL is a member project of the Software Freedom Conservancy. In general, [discussions about CWL should happen on open forums](https://mail.google.com/mail/u/0/#m_-135557084554140653_Support) but you can also contact the CWL leadership team & Conservancy directly via [commonworkflowlanguage@sfconservancy.org](mailto:commonworkflowlanguage@sfconservancy.org). This address should be CC'ed regarding all activities that involve activities of Common Workflow Language that related to things other than software development and documentation, and particularly any activities that expect to make use of Software Freedom Conservancy's non-profit status.
 
+To contact just the CWL leadership team, please email [cwl-leadership@googlegroups.com](mailto:cwl-leadership@googlegroups.com).
+
+The CWL leadership team consists of the following people, listed in alphabetical order by their last name:
 *   Peter Amstutz, Curii / Arvados Project; [https://orcid.org/0000-0003-3566-7705](https://orcid.org/0000-0003-3566-7705)
 *   John Chilton, Pennsylvania State University / Galaxy Project; [https://orcid.org/0000-0002-6794-0756](https://orcid.org/0000-0002-6794-0756)
 *   Michael R. Crusoe, CWL Project Lead; [https://orcid.org/0000-0002-2961-9670](https://orcid.org/0000-0002-2961-9670)

--- a/content/_includes/home/contributers-and-governance.html
+++ b/content/_includes/home/contributers-and-governance.html
@@ -87,7 +87,7 @@
 *   Stian Soiland-Reyes, University of Manchester; [https://orcid.org/0000-0001-9842-9718](https://orcid.org/0000-0001-9842-9718)
 *   Nebojša Tijanić, Seven Bridges
 *   Ward Vandewege, Curii / Arvados; [https://orcid.org/0000-0002-2527-6949](https://orcid.org/0000-0002-2527-6949)
-*   Alexander Wait Zaranek, Curoverse Inc. / Arvados; [https://orcid.org/0000-0002-0415-9655](https://orcid.org/0000-0002-0415-9655)
+ *   Alexander Wait Zaranek, Curri / Arvados; [https://orcid.org/0000-0002-0415-9655](https://orcid.org/0000-0002-0415-9655)
 
 <h3 id="CWL_Leadership_Team" class="section">CWL Leadership Team <a id="#CWL_Leadership_Team" href="#CWL_Leadership_Team" class="anchorfix"><span>§</span></a></h3>
 

--- a/content/_includes/home/video-player.html
+++ b/content/_includes/home/video-player.html
@@ -16,7 +16,7 @@
   </video>  
 </div>
 
-<script src="assets/plyr/plyr.min.js"></script>
+<script src="{{ "assets/plyr/plyr.min.js" | relative_url }}"></script>
 <script>
   const player = new Plyr('#player', {
     controls: [


### PR DESCRIPTION
Addresses:

1. Advisors - Sasha listed twice, fixes https://github.com/common-workflow-language/cwl-website/issues/51
2. CWL Leadership section - missing text, fixes https://github.com/common-workflow-language/cwl-website/issues/53
3. Production site - outputs links to staging site, fixes https://github.com/common-workflow-language/cwl-website/issues/54