### PR TITLE
Added citation for CWL preprint

### DIFF
--- a/content/_includes/home/specification.html
+++ b/content/_includes/home/specification.html
@@ -4,8 +4,16 @@ For developers and advanced users, the current [CWL Standards v1.2.0](https://ww
 
 <h3 id="Citation" class="section">Citation <a href="#Citation" class="anchorfix"><span>§</span></a></h3>
 
-To reference the CWL standards in a scholary work, please use the following citation inclusive of the DOI:
+To reference the Common Workflow Language and the CWL project in scholary work, please use the following citation:
 
-Peter Amstutz, Michael R. Crusoe, Nebojša Tijanić (editors), Brad Chapman, John Chilton, Michael Heuer, Andrey Kartashov, Dan Leehr, Hervé Ménager, Maya Nedeljkovich, Matt Scales, Stian Soiland-Reyes, Luka Stojanovic (2016): **Common Workflow Language, v1.0**. Specification, _Common Workflow Language working group_. [https://w3id.org/cwl/v1.0/](https://w3id.org/cwl/v1.0/) doi:[10.6084/m9.figshare.3115156.v2](https://doi.org/10.6084/m9.figshare.3115156.v2)
+Michael R. Crusoe, Sanne Abeln, Alexandru Iosup, Peter Amstutz, John Chilton, Nebojša Tijanić, Hervé Ménager, Stian Soiland-Reyes, Carole Goble, The CWL Community (2021):  
+**[Methods Included: Standardizing Computational Reuse and Portability with the Common Workflow Language](https://arxiv.org/pdf/2105.07028.pdf)**.  
+_arXiv_ **2105.07028** [cs.DC] <https://arxiv.org/abs/2105.07028>
+
+To reference the CWL **specification** in scholary work, please use the following citation inclusive of the DOI:
+
+Peter Amstutz, Michael R. Crusoe, Nebojša Tijanić (editors), Brad Chapman, John Chilton, Michael Heuer, Andrey Kartashov, Dan Leehr, Hervé Ménager, Maya Nedeljkovich, Matt Scales, Stian Soiland-Reyes, Luka Stojanovic (2016):  
+**Common Workflow Language, v1.0**.  
+Specification, _Common Workflow Language working group_. [https://w3id.org/cwl/v1.0/](https://w3id.org/cwl/v1.0/) <https://doi.org/10.6084/m9.figshare.3115156.v2>
 
 A collection of existing references to CWL can be found at [https://zotero.org/groups/cwl](https://www.zotero.org/groups/2294829/cwl/items)


### PR DESCRIPTION
Citing https://arxiv.org/abs/2105.07028 for now. Submitted to _Communications of the ACM_ - if/when it is accepted we can add "Accepted" etc.

I assume we'll keep also the figshare DOI for the specification itself. It would be nice if that could be updated for 1.1 and 1.2 though.