### PR TITLE
Fixes #79 - Broken link in Code Libraries section

### DIFF
--- a/content/_includes/home/software-for-working-with-cwl.html
+++ b/content/_includes/home/software-for-working-with-cwl.html
@@ -61,7 +61,7 @@
 {: .table .table-striped .rows-2}
 |Software|Description|
 |--- |--- |
-|[cwltool](https://github.com/common-workflow-language/cwltool)|cwltool (can be [imported as a Python module](https://www.commonwl.org/(https://github.com/common-workflow-language/cwltool#import-as-a-module)) and [extended to create custom cwl runners](https://github.com/common-workflow-language/cwltool#extension-points)|
+|[cwltool](https://github.com/common-workflow-language/cwltool)|cwltool (can be [imported as a Python module](https://github.com/common-workflow-language/cwltool#import-as-a-module) and [extended to create custom cwl runners](https://github.com/common-workflow-language/cwltool#extension-points)|
 |[schema salad](https://github.com/common-workflow-language/schema_salad)|Python module and tools for working with the CWL schema.|
 |[cwljava](https://github.com/common-workflow-lab/cwljava)|Java classes for loading, modifying, and creating CWL v1.2 documents|
 |[CWL for R](https://github.com/jefferys/cwl)|Parse and work with CWL from R|

--- a/content/_sass/partials/_variables.scss
+++ b/content/_sass/partials/_variables.scss
@@ -7,7 +7,7 @@ $container-max-widths: (
 
 $blue: #337ab7 !default;
 $dark-blue: #23527c !default;
-$grey: #f8f8f8;;
+$grey: #f8f8f8;
 $font-size-base:              0.875rem !default; // Assumes the browser default, typically `16px`
 $font-size-lg:                $font-size-base * 1.25 !default;
 $font-size-sm:                $font-size-base * .875 !default;


### PR DESCRIPTION
Fixes broken "imported as a Python module" link.
See specifically:
https://github.com/common-workflow-language/cwl-website/issues/79#issuecomment-922035986

Also removes a hanging ';' in /_sass/partials/_variables.scss