### PR TITLE
Update implementations.html

### DIFF
--- a/content/_includes/home/implementations.html
+++ b/content/_includes/home/implementations.html
@@ -18,7 +18,7 @@
 |--- |--- |--- |
 |[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.|&#8211;|
 |[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)|Alicloud, AWS, Google, HPC, Local, Spark, TES|
-|[Xenon](https://nlesc.github.io/Xenon/)|Run CWL workflows using Xenon|[any Xenon backend](https://nlesc.github.io/Xenon/): local, ssh, SLURM, Torque, Grid Engine |
+|[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
 |[Consonance](https://github.com/Consonance/consonance)|orchestration tool for running SeqWare workflows and CWL tools|AWS, OpenStack, Azure|
 |[AWE](https://github.com/MG-RAST/AWE)|Workflow and resource management system for bioinformatics data analysis.|&#8211;|
 |[yacle](https://github.com/otiai10/yacle)|Yet Another CWL Engine|local|

--- a/content/_includes/home/implementations.html
+++ b/content/_includes/home/implementations.html
@@ -19,10 +19,10 @@
 |[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.||&#8211;|
 |[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)||Alicloud, AWS, Google, HPC, Local, Spark, TES|
 |[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|![Required](https://badgen.net/https/raw.githubusercontent.com/xenon-middleware/xenon-flow/gh-pages/badges/required.json)|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
-|[Consonance](https://github.com/Consonance/consonance)|orchestration tool for running SeqWare workflows and CWL tools|AWS, OpenStack, Azure|
+|[Consonance](https://github.com/Consonance/consonance)|orchestration tool for running SeqWare workflows and CWL tools||AWS, OpenStack, Azure|
 |[AWE](https://github.com/MG-RAST/AWE)|Workflow and resource management system for bioinformatics data analysis.||&#8211;|
 |[yacle](https://github.com/otiai10/yacle)|Yet Another CWL Engine||local|
-|[Calrissian](https://github.com/Duke-GCB/calrissian)||CWL Engine built for Kubernetes|[Kubernetes](https://kubernetes.io/)|
+|[Calrissian](https://github.com/Duke-GCB/calrissian)|CWL Engine built for Kubernetes||[Kubernetes](https://kubernetes.io/)|
 |[Cromwell](https://github.com/broadinstitute/cromwell)|Cromwell workflow engine||Google, HTCondor, Local, LSF, PBS/Torque, SGE, Slurm, TES|
 |[CWLEXEC](https://github.com/IBMSpectrumComputing/cwlexec)|Apache 2.0 licensed CWL executor for IBM Spectrum LSF, supported by IBM for customers with valid contracts.||[IBM Spectrum LSF](https://developer.ibm.com/storage/products/ibm-spectrum-lsf/#) 10.1.0.3+|
 |[Mariner](https://github.com/uc-cdis/mariner)|"The Gen3 Workflow Execution Service", Apache 2.0 licensed, written in Go, also implements the [GA4GH WES API](https://ga4gh.github.io/workflow-execution-service-schemas)||[Kubernetes](https://kubernetes.io)|

--- a/content/_includes/home/implementations.html
+++ b/content/_includes/home/implementations.html
@@ -14,20 +14,20 @@
 <h3 id="Partial_Implementations" class="section">Partial Implementations: <a href="#Partial_Implementations" class="anchorfix"><span>§</span></a></h3>
 
 {: .table .table-striped .rows-3}
-|Software|Description|Platform support|
-|--- |--- |--- |
-|[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.|&#8211;|
-|[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)|Alicloud, AWS, Google, HPC, Local, Spark, TES|
-|[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
+|Software|Description|Compliance|Platform support|
+|--- |--- |--- |--- |
+|[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.||&#8211;|
+|[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)||Alicloud, AWS, Google, HPC, Local, Spark, TES|
+|[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|![Required](https://badgen.net/https/raw.githubusercontent.com/xenon-middleware/xenon-flow/gh-pages/badges/required.json)|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
 |[Consonance](https://github.com/Consonance/consonance)|orchestration tool for running SeqWare workflows and CWL tools|AWS, OpenStack, Azure|
-|[AWE](https://github.com/MG-RAST/AWE)|Workflow and resource management system for bioinformatics data analysis.|&#8211;|
-|[yacle](https://github.com/otiai10/yacle)|Yet Another CWL Engine|local|
-|[Calrissian](https://github.com/Duke-GCB/calrissian)|CWL Engine built for Kubernetes|[Kubernetes](https://kubernetes.io/)|
-|[Cromwell](https://github.com/broadinstitute/cromwell)|Cromwell workflow engine|Google, HTCondor, Local, LSF, PBS/Torque, SGE, Slurm, TES|
-|[CWLEXEC](https://github.com/IBMSpectrumComputing/cwlexec)|Apache 2.0 licensed CWL executor for IBM Spectrum LSF, supported by IBM for customers with valid contracts.|[IBM Spectrum LSF](https://developer.ibm.com/storage/products/ibm-spectrum-lsf/#) 10.1.0.3+|
-|[Mariner](https://github.com/uc-cdis/mariner)|"The Gen3 Workflow Execution Service", Apache 2.0 licensed, written in Go, also implements the [GA4GH WES API](https://ga4gh.github.io/workflow-execution-service-schemas)|[Kubernetes](https://kubernetes.io)|
-|[ep3](https://github.com/tom-tan/ep3)|Extremely Pluggable Pipeline Processor| local |
-|[Pegasus](https://pegasus.isi.edu/documentation/reference-guide/cwl-support.html)|Pegasus Workflow Management System|Partial support for importing CWL workflows is [under development](https://pegasus.isi.edu/documentation/manpages/pegasus-cwl-converter.html)|  
-|[StreamFlow](https://streamflow.di.unito.it/)|Workflow Management System for hybrid HPC-Cloud infrastructures|Full support for CWL 1.2 is currently under development|
+|[AWE](https://github.com/MG-RAST/AWE)|Workflow and resource management system for bioinformatics data analysis.||&#8211;|
+|[yacle](https://github.com/otiai10/yacle)|Yet Another CWL Engine||local|
+|[Calrissian](https://github.com/Duke-GCB/calrissian)||CWL Engine built for Kubernetes|[Kubernetes](https://kubernetes.io/)|
+|[Cromwell](https://github.com/broadinstitute/cromwell)|Cromwell workflow engine||Google, HTCondor, Local, LSF, PBS/Torque, SGE, Slurm, TES|
+|[CWLEXEC](https://github.com/IBMSpectrumComputing/cwlexec)|Apache 2.0 licensed CWL executor for IBM Spectrum LSF, supported by IBM for customers with valid contracts.||[IBM Spectrum LSF](https://developer.ibm.com/storage/products/ibm-spectrum-lsf/#) 10.1.0.3+|
+|[Mariner](https://github.com/uc-cdis/mariner)|"The Gen3 Workflow Execution Service", Apache 2.0 licensed, written in Go, also implements the [GA4GH WES API](https://ga4gh.github.io/workflow-execution-service-schemas)||[Kubernetes](https://kubernetes.io)|
+|[ep3](https://github.com/tom-tan/ep3)|Extremely Pluggable Pipeline Processor|| local |
+|[Pegasus](https://pegasus.isi.edu/documentation/reference-guide/cwl-support.html)|Pegasus Workflow Management System|Partial support for importing CWL workflows is [under development](https://pegasus.isi.edu/documentation/manpages/pegasus-cwl-converter.html)||
+|[StreamFlow](https://streamflow.di.unito.it/)|Workflow Management System for hybrid HPC-Cloud infrastructures|Full support for CWL 1.2 is currently under development||
 
 See also: [an ongoing analysis of CWL Implementations](https://docs.bioexcel.eu/cwl-engine-guide/about.html#summary-of-engines) by the BioExcel Center of Excellence.

--- a/content/_includes/home/implementations.html
+++ b/content/_includes/home/implementations.html
@@ -14,7 +14,7 @@
 <h3 id="Partial_Implementations" class="section">Partial Implementations: <a href="#Partial_Implementations" class="anchorfix"><span>§</span></a></h3>
 
 {: .table .table-striped .rows-3}
-|Software|Description|Compliance|Platform support|
+|Software|Description|Self-Reported Compliance|Platform support|
 |--- |--- |--- |--- |
 |[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.||&#8211;|
 |[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)||Alicloud, AWS, Google, HPC, Local, Spark, TES|

--- a/content/_includes/home/implementations.html
+++ b/content/_includes/home/implementations.html
@@ -18,7 +18,7 @@
 |--- |--- |--- |--- |
 |[Galaxy](https://galaxyproject.org/)|Web-based platform for data intensive biomedical research.||&#8211;|
 |[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas)||Alicloud, AWS, Google, HPC, Local, Spark, TES|
-|[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|![Required](https://badgen.net/https/raw.githubusercontent.com/xenon-middleware/xenon-flow/gh-pages/badges/required.json)|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
+|[xenonflow](https://github.com/xenon-middleware/xenonflow)|Run CWL workflows using Xenon through a REST api.|[![Required](https://badgen.net/https/raw.githubusercontent.com/xenon-middleware/xenon-flow/gh-pages/badges/required.json)](https://github.com/xenon-middleware/xenonflow#cwl-compliance)|[any Xenon backend](https://xenon-middleware.github.io/xenon/versions/3.1.0/javadoc/): local, ssh, SLURM, Torque, Grid Engine |
 |[Consonance](https://github.com/Consonance/consonance)|orchestration tool for running SeqWare workflows and CWL tools||AWS, OpenStack, Azure|
 |[AWE](https://github.com/MG-RAST/AWE)|Workflow and resource management system for bioinformatics data analysis.||&#8211;|
 |[yacle](https://github.com/otiai10/yacle)|Yet Another CWL Engine||local|


### PR DESCRIPTION
With the v1 release of xenonflow I thought it would be good to have it in the list of partial implementations on the cwl website.

I discussed with @jmaassen and we agreed that the Xenon entry should point to the xenonflow repository since it's xenonflow that is developed to be a runner while Xenon has no direct support for running cwl files.

I've updated the implementation.html to reflect this

