### PR TITLE
Fix HTML Validator issues from #99

### DIFF
--- a/content/_includes/footer-scripts.html
+++ b/content/_includes/footer-scripts.html
@@ -1,7 +1,7 @@
-<script type="text/javascript" src="{{ "/assets/js/jquery-3.5.1.min.js" | relative_url }}"></script>
-<script type="text/javascript" src="{{ "/assets/js/bootstrap.min.js" | relative_url }}"></script>
-<script type="text/javascript" src="{{ "/assets/js/backToTop.js" | relative_url }}"></script>
-<script type="text/javascript" src="{{ "/assets/js/navCloseFix.js" | relative_url }}"></script>
+<script src="{{ "/assets/js/jquery-3.5.1.min.js" | relative_url }}"></script>
+<script src="{{ "/assets/js/bootstrap.min.js" | relative_url }}"></script>
+<script src="{{ "/assets/js/backToTop.js" | relative_url }}"></script>
+<script src="{{ "/assets/js/navCloseFix.js" | relative_url }}"></script>
 
 {% if jekyll.environment == "staging" %}
   {% include hypothesis.html %}

--- a/content/_includes/head.html
+++ b/content/_includes/head.html
@@ -2,14 +2,13 @@
   <title>{{ page.title }} | Common Workflow Language (CWL)</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="sitemap" type="application/xml" title="Sitemap" href={{ "/sitemap.xml" | relative_url }}>
 
-  {%- seo -%}
+  {%- seo title=false -%}
 
-  <script type="text/javascript" src="{{ "/assets/js/redirects.js" | relative_url }}"></script>
+  <script src="{{ "/assets/js/redirects.js" | relative_url }}"></script>
 
   {%- if page.url contains "gallery" -%}
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/content/_includes/home/feature-boxes.html
+++ b/content/_includes/home/feature-boxes.html
@@ -1,4 +1,4 @@
-<section class="features-grid">
+<div class="features-grid">
 {%- for feature in site.data.home.feature_boxes -%}
   <div class="feature-item {{ feature.title | downcase | replace: " ", "-" }}">
     <a class="feature-title" href="{{ feature.box_url }}">{{ feature.title }}</a>
@@ -6,5 +6,5 @@
     <p class="feature-text">{{ feature.text | markdownify | remove: "<p>" | remove: "</p>" }}</p>
   </div>
 {%- endfor -%}
-</section>
+</div>
 

--- a/content/_includes/home/intro.html
+++ b/content/_includes/home/intro.html
@@ -1,4 +1,4 @@
-<section class="page-section intro-container">
+<div class="page-section intro-container">
   <div class="intro-text">
     <p>Common Workflow Language (CWL) is an open standard for describing how to run command line tools and connect them to create workflows.</p>
     <p>Tools and workflows described using CWL are portable across a
@@ -10,4 +10,4 @@
   </div>
 
   {%- include home/video-player.html -%}
-</section>
+</div>

--- a/content/_includes/home/mini-gallery.html
+++ b/content/_includes/home/mini-gallery.html
@@ -11,7 +11,11 @@
     {%- for adopter in adopters -%}
       {%- if adopter.image -%}
         {%- unless adopter.duplicate_logo == true -%}
-          <div id="{{ adopter.image_id }}-container" class="mini-gallery-img-container"><img id="{{ adopter.image_id }}" class="mini-gallery-img" src="{{ adopter.image | absolute_url }}" alt=""></div>
+          {%- if adopter.image_id -%}
+            <div id="{{ adopter.image_id }}-container" class="mini-gallery-img-container"><img id="{{ adopter.image_id }}" class="mini-gallery-img" src="{{ adopter.image | absolute_url }}" alt=""></div>
+          {% else %}
+          <div class="mini-gallery-img-container"><img class="mini-gallery-img" src="{{ adopter.image | absolute_url }}" alt=""></div>
+          {% endif %}
         {%- endunless -%}
       {%- endif -%}
     {%- endfor -%}

--- a/content/_includes/home/video-player.html
+++ b/content/_includes/home/video-player.html
@@ -1,10 +1,10 @@
-<div class="youtube-container" width="560" height="315">
+<div class="youtube-container">
   <video id="player" class="cwl-intro-video" controls poster="{{ "/assets/img/intro_video_poster.png" | relative_url }}">
     <source src="{{ "/assets/video/cwl-intro-video.mp4" | relative_url }}" type="video/mp4">
 
     <track src="{{ "/assets/video/subtitles/chinese_simplified.vtt" | relative_url }}" label="Chinese (Simplified)" kind="subtitles" srclang="zh-Hans">
-    <track src="{{ "/assets/video/subtitles/english.vtt" | relative_url }}" label="English" kind="captions" srclang="en_US" default>
-    <track src="{{ "/assets/video/subtitles/french.vtt" | relative_url }}" label="French" kind="subtitles" srclang="fr_FR">
+    <track src="{{ "/assets/video/subtitles/english.vtt" | relative_url }}" label="English" kind="captions" srclang="en-us" default>
+    <track src="{{ "/assets/video/subtitles/french.vtt" | relative_url }}" label="French" kind="subtitles" srclang="fr-fr">
     <track src="{{ "/assets/video/subtitles/japanese.vtt" | relative_url }}" label="Japanese" kind="subtitles" srclang="ja">
     <track src="{{ "/assets/video/subtitles/lithuanian.vtt" | relative_url }}" label="Lithuanian" kind="subtitles" srclang="lt">
     <track src="{{ "/assets/video/subtitles/romanian.vtt" | relative_url }}" label="Romanian" kind="subtitles" srclang="ro">

--- a/content/_includes/top_nav.html
+++ b/content/_includes/top_nav.html
@@ -13,7 +13,7 @@
         {%- for item in site.data.navigation.header -%}
           {%- if item.type contains "dropdown" -%}
             <li class="dropdown nav-item">
-              <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" data-bs-toggle="dropdown" role="button" aria-expanded="false">{{ item.title}}<span class="caret"></span></a>
+              <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown-{{ item.title }}" data-bs-toggle="dropdown" role="button" aria-expanded="false">{{ item.title}}<span class="caret"></span></a>
               {%- if item.subpages -%}
                 <ul class="dropdown-menu">
                 {%- for page in item.subpages -%}
@@ -27,7 +27,7 @@
               {%- endif -%}
 
             {%- if item.subfolderitems[0] -%}
-              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown-{{ item.title }}">
                 {%- for entry in item.subfolderitems -%}
                   <li class="dropdown-item nav-item"><a class="nav-link" href="{{ entry.url | absolute_url }}">{{ entry.page }}</a></li>
                 {%- endfor -%}
@@ -50,7 +50,7 @@
         <a href="{{ site.twitter_url }}" aria-label="Twitter link"><i class="fab fa-twitter"></i></a>
         <a href="{{ site.youtube_url }}" aria-label="YouTube link"><i class="fab fa-youtube"></i></a>
         <a href="{{ site.matrix_url }}" class="matrix-link" aria-label="Matrix link">
-          <svg width="26" height="29.7" class="matrix-svg" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" version="1.1" viewBox="0 0 27.9 32">
+          <svg width="26" height="29.7" class="matrix-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27.9 32">
            <title>Matrix (protocol) logo</title>
            <g transform="translate(-.095 .005)" fill="#040404">
             <path d="m27.1 31.2v-30.5h-2.19v-0.732h3.04v32h-3.04v-0.732z"/>

--- a/content/_layouts/default.html
+++ b/content/_layouts/default.html
@@ -20,7 +20,7 @@
     <div class="container content-wrapper">
       <div class="row">
       {%- if page.columns -%}
-        <main class="col-lg-{{page.columns}}" role="main" id="main">
+        <main class="col-lg-{{page.columns}}" id="main">
       {%- else -%}
         <main role="main" id="main">
       {%- endif -%}

--- a/content/_sass/partials/home/_video.scss
+++ b/content/_sass/partials/home/_video.scss
@@ -1,6 +1,8 @@
 // Video Player
 .youtube-container {
+  height: 315px;
   padding: 15px 0;
+  width: 560px;
 
   iframe,
   video {

--- a/content/_sass/partials/home/_video.scss
+++ b/content/_sass/partials/home/_video.scss
@@ -1,6 +1,7 @@
 // Video Player
 .youtube-container {
   height: 315px;
+  max-width: 100%;
   padding: 15px 0;
   width: 560px;
 

--- a/content/_sass/partials/home/_video.scss
+++ b/content/_sass/partials/home/_video.scss
@@ -1,9 +1,8 @@
 // Video Player
 .youtube-container {
-  height: 315px;
+  max-height: 315px;
   max-width: 100%;
   padding: 15px 0;
-  width: 560px;
 
   iframe,
   video {
@@ -11,9 +10,26 @@
   }
 }
 
+@include media-breakpoint-up(sm) {
+  .youtube-container {
+    height: auto;
+    max-height: none;
+    min-height: 315px;
+  }
+}
+
 @include media-breakpoint-up(lg) {
   .youtube-container {
     margin: 0 0 0 36px;
+    padding: 0 0 15px;
+    width: 50%;
+  }
+}
+
+@include media-breakpoint-up(xl) {
+  .youtube-container {
+    max-height: initial;
+    min-height: initial;
     padding: 0 0 15px;
     width: 40%;
   }


### PR DESCRIPTION
Fixes the following errors/warnings for:

* Duplicate <meta> tag with http-equiv="Content-Type"
* Duplicate <title> tag in <head>
* Duplicate IDs (#nabarDropdown) in Nav bar
* Unnecessary role="main" in <main> tag
* Width & Height attributes in <div> tags are deprecated
* Bad srclang values in video-player.html. Changed en_US to en-us and fr_FR to fr-fr
* Unnecessary type="text/javascript" in javascript <srcipt> tagss
* Duplicate IDs in Mini Gallery