### PR TITLE
Add sapporo and shaft to the list

### DIFF
--- a/content/implementations.md
+++ b/content/implementations.md
@@ -40,6 +40,7 @@ particular technology configuration they deploy and maintain.
 
 {:.cwl-red}
 ### In Production for CommandLineTool
+
 {: .table .cols-3}
 |Software|Description| Self-Reported Compliance | Platform support|
 |--- |--- |--- |--- |

--- a/content/implementations.md
+++ b/content/implementations.md
@@ -39,6 +39,13 @@ particular technology configuration they deploy and maintain.
 |[StreamFlow](https://streamflow.di.unito.it/)|Workflow Management System for hybrid HPC-Cloud infrastructures|[CWL v1.0 - v1.2 ![Required](https://badgen.net/https/streamflow.di.unito.it/cwl-conformance/v1.2/required.json?icon=commonwl)](https://github.com/alpha-unito/streamflow#cwl-compatibility)<br />(and [nearly all optional features](https://github.com/alpha-unito/streamflow#cwl-compatibility))|Kubernetes, HPC with Singularity (PBS, Slurm), [Occam](https://c3s.unito.it/index.php/super-computer), multi-node SSH, local-only (Docker, Singularity)|
 
 {:.cwl-red}
+### In Production for CommandLineTool
+{: .table .cols-3}
+|Software|Description| Self-Reported Compliance | Platform support|
+|--- |--- |--- |--- |
+|[shaft](https://github.com/tom-tan/shaft)|A workflow engine for CWL CommandLineTool|[CWL v1.0 ![Required](https://badgen.net/https/raw.githubusercontent.com/tom-tan/conformance/master/shaft/cwl_v1.0/shaft_latest/required.json?icon=commonwl)](https://github.com/tom-tan/shaft#conformance-tests-for-cwl-v10)| local |
+
+{:.cwl-red}
 ### Partial implementations
 
 {: .table .cols-3}
@@ -51,7 +58,7 @@ particular technology configuration they deploy and maintain.
 |[cwl-tes](https://github.com/ohsu-comp-bio/cwl-tes)|CWL engine backended by the [GA4GH Task Execution API](https://github.com/ga4gh/task-execution-schemas) | |Alicloud, AWS, Google, HPC, local, Spark, TES|
 |[Calrissian](https://github.com/Duke-GCB/calrissian)|CWL Engine built for Kubernetes| |[Kubernetes](https://kubernetes.io/)|
 |[Pegasus](https://pegasus.isi.edu/documentation/reference-guide/cwl-support.html)|Pegasus Workflow Management System| Partial support for importing CWL workflows is [under development](https://pegasus.isi.edu/documentation/manpages/pegasus-cwl-converter.html) | |
-|[Weaver](https://github.com/crim-ca/weaver)|Workflow Execution Management Service (EMS) and Application, Deployment and Execution Service (ADES) that can interact and chain [OGC API - Processes][OAPIP], [Web Processing Service][WPS] (WPS) and [Earth System Grid Federation][ESGF] (ESGF) [Compute API][ESGF-CWT] processes using CWL. | CWL v1.0 - v1.2 <br> Partial support according to possible conversions between processes (see [Application Package][AppPkg] for details). | Docker, CUDA GPU, [OGC API - Procsses][OAPIP], [WPS][WPS], [ESGF-CWT][ESGF-CWT], remote Web API, local CLI | 
+|[Weaver](https://github.com/crim-ca/weaver)|Workflow Execution Management Service (EMS) and Application, Deployment and Execution Service (ADES) that can interact and chain [OGC API - Processes][OAPIP], [Web Processing Service][WPS] (WPS) and [Earth System Grid Federation][ESGF] (ESGF) [Compute API][ESGF-CWT] processes using CWL. | CWL v1.0 - v1.2 <br> Partial support according to possible conversions between processes (see [Application Package][AppPkg] for details). | Docker, CUDA GPU, [OGC API - Procsses][OAPIP], [WPS][WPS], [ESGF-CWT][ESGF-CWT], remote Web API, local CLI |
 
 [AppPkg]: https://pavics-weaver.readthedocs.io/en/latest/package.html
 [ESGF]: https://esgf.llnl.gov/

--- a/content/implementations.md
+++ b/content/implementations.md
@@ -39,7 +39,7 @@ particular technology configuration they deploy and maintain.
 |[StreamFlow](https://streamflow.di.unito.it/)|Workflow Management System for hybrid HPC-Cloud infrastructures|[CWL v1.0 - v1.2 ![Required](https://badgen.net/https/streamflow.di.unito.it/cwl-conformance/v1.2/required.json?icon=commonwl)](https://github.com/alpha-unito/streamflow#cwl-compatibility)<br />(and [nearly all optional features](https://github.com/alpha-unito/streamflow#cwl-compatibility))|Kubernetes, HPC with Singularity (PBS, Slurm), [Occam](https://c3s.unito.it/index.php/super-computer), multi-node SSH, local-only (Docker, Singularity)|
 
 {:.cwl-red}
-### In Production for CommandLineTool
+### In Production for CommandLineTools only
 
 {: .table .cols-3}
 |Software|Description| Self-Reported Compliance | Platform support|

--- a/content/tools.md
+++ b/content/tools.md
@@ -54,6 +54,7 @@ can be used to provide a programmatic API or user interface to orchestrate execu
 |[WfExS](https://github.com/inab/WfExS-backend)|Workflow Execution Service supporting GA4GH Tools Registry Service ([TRS](https://github.com/ga4gh/tool-registry-service-schemas)) API, [RO-Crate](https://w3id.org/ro/crate), Nextflow and CWL|
 |[workflow-service](https://github.com/common-workflow-language/workflow-service)|An implementation of the [GA4GH Workflow Execution Service (WES)](https://github.com/ga4gh/workflow-execution-service-schemas) API to run CWL workflows on remote clusters|
 |[workflUX](https://github.com/workflux/workflUX)|Web interface for simplified execution of CWL workflows|
+|[Sapporo](https://github.com/sapporo-wes/sapporo)|An implementation of Workflow Execution Service (WES) or so-called Workflow-as-a-Service|
 
 ### Utilities {#utils}
 

--- a/content/tools.md
+++ b/content/tools.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 permalink: /tools/
-title: Development Tools 
+title: Development Tools
 redirect_from:
   - /ecosystem/
   - /development-tools/
@@ -43,7 +43,7 @@ Other tools are also available in [Common Workflow Language Lab](https://github.
 
 ### Execution frameworks {#execution}
 
-While [CWL implementations](/implementations/) can execute workflows on different compute backends, the frameworks below 
+While [CWL implementations](/implementations/) can execute workflows on different compute backends, the frameworks below
 can be used to provide a programmatic API or user interface to orchestrate execution with an CWL implementation.
 
 {: .table .table-striped .cols-2}
@@ -54,7 +54,7 @@ can be used to provide a programmatic API or user interface to orchestrate execu
 |[WfExS](https://github.com/inab/WfExS-backend)|Workflow Execution Service supporting GA4GH Tools Registry Service ([TRS](https://github.com/ga4gh/tool-registry-service-schemas)) API, [RO-Crate](https://w3id.org/ro/crate), Nextflow and CWL|
 |[workflow-service](https://github.com/common-workflow-language/workflow-service)|An implementation of the [GA4GH Workflow Execution Service (WES)](https://github.com/ga4gh/workflow-execution-service-schemas) API to run CWL workflows on remote clusters|
 |[workflUX](https://github.com/workflux/workflUX)|Web interface for simplified execution of CWL workflows|
-|[Sapporo](https://github.com/sapporo-wes/sapporo)|An implementation of Workflow Execution Service (WES) or so-called Workflow-as-a-Service|
+|[Sapporo](https://github.com/sapporo-wes/sapporo)|An implementation of Workflow Execution Service (WES) standard or so-called Workflow-as-a-Service. Explicit CWL support using `cwltool` or `toil-cwl-runner`.|
 
 ### Utilities {#utils}
 


### PR DESCRIPTION
This request adds the following systems to the list.
- [shaft](https://github.com/tom-tan/shaft) to the `Implementation` list: A workflow engine for CWL CommandLineTool
  - As @mr-c suggested, I introduced `In Production for CommandLineTool` category.
- [Sapporo](https://github.com/sapporo-wes/sapporo) to the `Execution frameworks` list: An implementation of Workflow Execution Service (WES) or so-called Workflow-as-a-Service.
