### PR TITLE
Add Working Groups section

### DIFF
--- a/content/Gemfile
+++ b/content/Gemfile
@@ -29,3 +29,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
+
+gem "webrick", "~> 1.8"

--- a/content/Gemfile.lock
+++ b/content/Gemfile.lock
@@ -85,8 +85,10 @@ GEM
     unicode-display_width (1.8.0)
     uri (0.12.2)
     wdm (0.1.1)
+    webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-23
   x64-mingw32
   x86_64-linux
 
@@ -102,6 +104,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.2.22

--- a/content/_data/navigation.yml
+++ b/content/_data/navigation.yml
@@ -31,6 +31,8 @@ header:
         url: /repos
       - title: Projects
         url: /projects
+      - title: Working Groups
+        url: /working-groups
   - title: Specification
     url: /specification
   - title: User Gallery

--- a/content/working-groups.md
+++ b/content/working-groups.md
@@ -1,0 +1,22 @@
+---
+layout: page
+permalink: /working-groups/
+title: Working Groups
+columns: 10
+class: page-short
+---
+
+{:.black-text}
+## Working Groups officially recognized by the CWL community
+
+According to the openness OpenStand principle, anyone can discuss, propose, and test ideas about the Common Workflow Language standard.
+Given that, working groups are not the unique nor the preferred way to advance the standard.
+At the same time, focus groups with a vertical interest in a specific advancement direction represent flourishing environments where to build, refine, and validate high-quality CWL enhancement proposals, mixing the competencies of domain experts, CWL users and workflow system implementers.
+
+To add a new Working Group to the list below, submit a proposal to the [CWL Leadership Team](/governance/) with the name, the scope, and a short description of the focus group, together with the contacts of the group leaders. The leaders will be in charge of updating the CWL Website with the main advancements and achievements of the Working Group.
+
+{: .table .table-striped .cols-2 }
+|Name|Scope|
+|--- |--- |
+|[CWL4HPC](/working-groups/cwl4hpc) | Identify workflow patterns capable of modeling large-scale scientific applications and implement the related CWL enhancement proposals.|
+|

--- a/content/working-groups/CWL4HPC.md
+++ b/content/working-groups/CWL4HPC.md
@@ -1,0 +1,39 @@
+---
+layout: page
+permalink: /working-groups/cwl4hpc
+title: CWL4HPC Working Group
+columns: 10
+class: page-short
+---
+
+
+{:.black-text}
+## CWL For High-Performance Computing (CWL4HPC)
+
+The CWL4HPC Working group aims to identify workflow patterns capable of modelling large-scale scientific applications and implement the related CWL enhancement proposals. The main objective is to enable the CWL ecosystem to easily describe HPC workloads and orchestrate them at extreme scales without sacrificing the general and agnostic nature of the language.
+
+The main activities of the group are listed in the table below. For each CWL enhancement proposal, the group aims to:
+ - Motivate it with two real use cases that would benefit from the proposed feature;
+ - Agree on a first draft of the syntax and semantics of the proposed feature;
+ - Implement it as an extension on `cwltool` (the CWL reference implementation) and at least another CWL-compliant workflow system;
+ - Validate it on at least two real CWL workflows.
+
+The process just described is iterative. If some criticalities of further enhancements emerge during the implementation or validation phases, the syntax and semantics can be refined and the process restarts. After reaching a sufficient level of maturity, the group agrees to present the proposal to the CWL community for inclusion in the following standard version.
+
+Domain experts, HPC administrators, workflow designers and maintainers, and workflow system implementers are welcome to join the discussion, but the group is open to anyone wanting to contribute. Click [here](https://matrix.to/#/!rnpqRUgCiUQaGeqAWG:matrix.org?via=matrix.org) to join the group's matrix channel and participate in the discussion.
+
+### Leads
+
+ - Iacopo Colonnelli, University of Torino, Italy (iacopo.colonnelli@unito.it)
+ - Bruno P. Kinoshita, Barcelona Supercomputing Center, Spain (bruno.depaulakinoshita@bsc.es)
+
+### Main ongoing activities
+
+{: .table .table-striped .cols-2 }
+|Feature|Status|
+|--- |--- |
+| Iterative patterns| A `cwltool:Loop` requirement has been [proposed](https://github.com/common-workflow-language/common-workflow-language/issues/495) and implemented as a CWL extension in [cwltool](https://github.com/common-workflow-language/cwltool) and [StreamFlow](https://streamflow.di.unito.it). Currently, its inclusion in the CWL v1.3 standard as a [native feature](https://github.com/common-workflow-language/cwltool/pull/1779) is under discussion |
+
+### Publications
+
+- I. Colonnelli, B. Casella, G. Mittone, Y. Arfat, B. Cantalupo, R. Esposito, A. R. Martinelli, D. Medić, and M. Aldinucci, “Federated Learning meets HPC and cloud,” in *Astrophysics and Space Science Proceedings*, Catania, Italy, 2023, p. 193–199. doi:[10.1007/978-3-031-34167-0_39](https://dx.doi.org/10.1007/978-3-031-34167-0_39)

--- a/content/working-groups/CWL4HPC.md
+++ b/content/working-groups/CWL4HPC.md
@@ -15,8 +15,8 @@ The CWL4HPC Working group aims to identify workflow patterns capable of modellin
 The main activities of the group are listed in the table below. For each CWL enhancement proposal, the group aims to:
  - Motivate it with two real use cases that would benefit from the proposed feature;
  - Agree on a first draft of the syntax and semantics of the proposed feature;
- - Implement it as an extension on `cwltool` (the CWL reference implementation) and at least another CWL-compliant workflow system;
- - Validate it on at least two real CWL workflows.
+ - Implement it as an extension on `cwltool` (the CWL reference implementation) and at least another CWL-compliant workflow system, together with a suite of conformance tests;
+ - Validate it on at least two existing CWL workflows where the proposal is applied, or with new example workflows created on purpose.
 
 The process just described is iterative. If some criticalities of further enhancements emerge during the implementation or validation phases, the syntax and semantics can be refined and the process restarts. After reaching a sufficient level of maturity, the group agrees to present the proposal to the CWL community for inclusion in the following standard version.
 


### PR DESCRIPTION
This commit adds a Working Groups section to track CWL focus groups on specific topics. The CWL4HPC working group has been added as an example, hoping that more activities will come in the future.