### PR TITLE
Fix navbar indent after wrap

### DIFF
--- a/content/_sass/partials/_user-gallery.scss
+++ b/content/_sass/partials/_user-gallery.scss
@@ -11,21 +11,18 @@
 
   &.has-left-nav {
     .left-nav {
-      a {
-        margin: 5px 5px 0 15px;
-      }
-
       .left-nav-links {
         list-style: none;
         padding: 2px 0;
 
         .no-indent {
-          margin-left: 0;
+          margin: 5px 5px 0 15px;
         }
       }
 
       .indent {
-        margin: 5px 5px 5px 30px;
+        margin: 5px 5px 5px 15px;
+        text-indent: 0;
      }
     }
   }


### PR DESCRIPTION
This commit fixes the left space after a newline on the User Gallery left navbar. In detail, it moves the margin from the `<a>` element to the upper `<li>` element.